### PR TITLE
Increase the Virtual Memory ratio for more RAM space

### DIFF
--- a/mm/vmscan.c
+++ b/mm/vmscan.c
@@ -137,7 +137,7 @@ struct scan_control {
 /*
  * From 0 .. 100.  Higher means more swappy.
  */
-int vm_swappiness = 60;
+int vm_swappiness = 80;
 /*
  * The total number of pages which are beyond the high watermark within all
  * zones.


### PR DESCRIPTION
Use the following commit to allow the kernel to allocate more memory for the RAM rather than dumping everything in to the RAM itself.